### PR TITLE
add missing kconfig/cmake files

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright (c) 2020 Linumiz
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_LZ4)
+  set(LZ4_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
+
+  zephyr_library()
+
+  zephyr_include_directories(${LZ4_DIR}/lib)
+
+  zephyr_library_compile_definitions_ifdef(CONFIG_LZ4_HEAPMODE_STACK
+    LZ4_HEAPMODE=0
+  )
+
+  zephyr_library_compile_definitions_ifdef(CONFIG_LZ4_DISABLE_DYNAMIC_MEMORY_ALLOCATION
+    LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION
+  )
+
+  zephyr_library_compile_definitions(
+    LZ4_MEMORY_USAGE=${CONFIG_LZ4_MEMORY_USAGE}
+  )
+
+  zephyr_library_sources(
+    ${LZ4_DIR}/lib/lz4.c
+  )
+
+  zephyr_library_sources_ifdef(CONFIG_LZ4_HIGH_COMPRESSION_VARIANT
+    ${LZ4_DIR}/lib/lz4hc.c
+  )
+
+  zephyr_library_compile_definitions_ifdef(CONFIG_LZ4HC_HEAPMODE_STACK
+    LZ4HC_HEAPMODE=0
+  )
+
+  zephyr_library_sources_ifdef(CONFIG_LZ4_XX_HASH
+    ${LZ4_DIR}/lib/xxhash.c
+  )
+
+  zephyr_library_sources_ifdef(CONFIG_LZ4_FRAME_SUPPORT
+    ${LZ4_DIR}/lib/lz4frame.c
+  )
+
+  zephyr_library_compile_definitions_ifdef(CONFIG_LZ4F_HEAPMODE_HEAP
+    LZ4F_HEAPMODE=1
+  )
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,102 @@
+# Copyright (c) 2020 Linumiz
+# SPDX-License-Identifier: Apache-2.0
+
+config ZEPHYR_LZ4_MODULE
+	bool
+
+menuconfig LZ4
+	bool "Lz4 data compression and decompression"
+	help
+	  This option enables lz4 compression & decompression library
+	  support.
+if LZ4
+
+config LZ4_MEMORY_USAGE
+	int "Lz4 memory usage"
+	range 10 20
+	default 14
+	help
+	  Increasing memory usage improves compression ratio, but usually at the
+	  cost of speed, due to cache locality. Memory usage 2^value (10 -> 1KB,
+	  12 -> 4KB, 20 -> 1MB).
+
+config LZ4_DISABLE_DYNAMIC_MEMORY_ALLOCATION
+	bool "Disable dynamic memory allocation"
+	help
+	  Disable lz4 functions that use dynamic memory allocation functions.
+
+choice LZ4_HEAPMODE
+	prompt "How stateless compression functions allocate memory for their hash table"
+	default LZ4_HEAPMODE_HEAP
+
+config LZ4_HEAPMODE_STACK
+	bool "in memory stack"
+	help
+	  Allocate memory from stack (fastest).
+
+config LZ4_HEAPMODE_HEAP
+	bool "in memory heap"
+	depends on !LZ4_DISABLE_DYNAMIC_MEMORY_ALLOCATION
+	help
+	  Allocate memory from heap (requires malloc()).
+endchoice
+
+config LZ4_HIGH_COMPRESSION_VARIANT
+	bool "Lz4 high compression variant"
+	help
+	  For more compression ratio at the cost of compression speed,
+	  the High Compression variant called lz4hc is available. This variant
+	  also compresses data using the lz4 block format.
+
+if LZ4_HIGH_COMPRESSION_VARIANT
+choice LZ4HC_HEAPMODE
+	prompt "How stateless HC compression functions allocate memory for their workspace"
+	default LZ4HC_HEAPMODE_HEAP
+
+config LZ4HC_HEAPMODE_STACK
+	bool "in memory stack"
+	help
+	  Allocate memory from stack (fastest).
+
+config LZ4HC_HEAPMODE_HEAP
+	bool "in memory heap"
+	depends on !LZ4_DISABLE_DYNAMIC_MEMORY_ALLOCATION
+	help
+	  Allocate memory from heap (requires malloc()).
+endchoice
+endif
+
+config LZ4_XX_HASH
+	bool "xxHash hashing algorithm"
+	help
+	  Build xxHash library included in lz4 sources.
+
+config LZ4_FRAME_SUPPORT
+	bool "LZ4 frame support"
+	select LZ4_XX_HASH
+	select LZ4_HIGH_COMPRESSION_VARIANT
+	help
+	  In order to produce compressed data compatible with lz4 command line
+	  utility, it's necessary to use the official interoperable frame format.
+	  This format is generated and decoded automatically by the lz4frame library.
+	  Its public API is described in lib/lz4frame.h.
+
+if LZ4_FRAME_SUPPORT
+choice LZ4F_HEAPMODE
+	prompt "Control how LZ4F_compressFrame() allocates the Compression State"
+	default LZ4F_HEAPMODE_STACK
+
+config LZ4F_HEAPMODE_STACK
+	bool "in memory stack"
+	help
+	  Allocate memory from stack (fastest).
+
+config LZ4F_HEAPMODE_HEAP
+	bool "in memory heap"
+	depends on !LZ4_DISABLE_DYNAMIC_MEMORY_ALLOCATION
+	help
+	  Allocate memory from heap (requires malloc()).
+endchoice
+endif
+
+endif

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,4 @@
 name: lz4
 build:
-  cmake-ext: True
-  kconfig-ext: True
+  cmake: zephyr/
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
Missed Kconfig and CMake files while move to external.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/107363

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
