### PR TITLE
zephyr: kconfig: auto-enable for RAM disk decompressor

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -6,10 +6,16 @@ config ZEPHYR_LZ4_MODULE
 
 menuconfig LZ4
 	bool "Lz4 data compression and decompression"
+	default y if RAM_LZ4_DECOMPRESSOR
 	help
 	  This option enables lz4 compression & decompression library
 	  support.
 if LZ4
+
+config LZ4_AUTO_ENABLE_FRAME_FOR_RAM_DISK
+	bool "Auto enable frame support if ramdisk decompression enabled"
+	select LZ4_FRAME_SUPPORT
+	default y if RAM_LZ4_DECOMPRESSOR
 
 config LZ4_MEMORY_USAGE
 	int "Lz4 memory usage"


### PR DESCRIPTION
Introduce a Kconfig mechanism to automatically enable the LZ4 library and its frame format support when the core Zephyr symbol RAM_LZ4_DECOMPRESSOR is active.

Because core Zephyr drivers cannot directly select external module symbols without breaking isolated CI compliance linters, this implements the demand pattern. The core driver signals its requirement via a core symbol, and the LZ4 module safely catches it and cascades the necessary selections down to the frame and hash sub-dependencies.

The solution for [zephyr ramdisk decompression PR](https://github.com/zephyrproject-rtos/zephyr/pull/111327), which uses LZ4 as external module